### PR TITLE
Fix undefined name TranslationError

### DIFF
--- a/_translation/_types.py
+++ b/_translation/_types.py
@@ -178,13 +178,13 @@ def set_dst_var_types(vis, arg_types):
         elif i.opcode == dis.OpCode.CALL_FUNCTION:
             fn_i = var_setters[i.src_vars[0]]
             if fn_i.opcode != dis.OpCode.LOAD_CONST:
-                raise TranslationError(
+                raise py2bpf.exception.TranslationError(
                     i.starts_line,
                     'Cannot invoke dynamically selected functions')
             fn = fn_i.argval
             if (not isinstance(fn, py2bpf.funcs.PseudoFunc) and
                     not isinstance(fn, py2bpf.funcs.Func)):
-                raise TranslationError(
+                raise py2bpf.exception.TranslationError(
                     i.starts_line,
                     'Can only invoke py2bpf.funcs.Func or PseudoFunc')
             update_single_dst(i, fn.return_type)


### PR DESCRIPTION
Change __TranslationError__ --> __py2bpf.exception.TranslationError__ to match the other instances and resolve two undefined names.

flake8 testing of https://github.com/facebookresearch/py2bpf on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./_translation/_types.py:181:23: F821 undefined name 'TranslationError'
                raise TranslationError(
                      ^
./_translation/_types.py:187:23: F821 undefined name 'TranslationError'
                raise TranslationError(
                      ^
2     F821 undefined name 'TranslationError'
2
```